### PR TITLE
Add attribution for Apache Commons VFS

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,6 +1,6 @@
 = Groovy VFS
 
-A DSL for Groovy to wrap around the Apache VFS libraries.
+A DSL for Groovy to wrap around the link:http://commons.apache.org/proper/commons-vfs/[Apache Commons VFS] libraries.
 
 If you like it, then tweet about it using ```#groovyvfs``` as the hashtag.
 


### PR DESCRIPTION
Correct the name of the library used by groovy-vfs and add a link to the project website.
